### PR TITLE
Update .tool-versions file

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,29 +1,19 @@
-# renovate: datasource=github-tags depName=npryce/adr-tools
 adr-tools 3.0.0
 awscli 2.11.27
-# renovate: datasource=github-tags depName=bridgecrewio/checkov
 checkov 2.3.234
-# renovate: datasource=github-tags depName=fluxcd/flux2
 flux2 0.41.2
 golang 1.20.5
-# renovate: datasource=github-tags depName=golangci/golangci-lint
 golangci-lint 1.53.2
-# renovate: datasource=github-tags depName=hadolint/hadolint
 hadolint 2.12.0
 helm 3.12.0
 # renovate: datasource=github-tags depName=derailed/k9s
 k9s 0.27.4
-# renovate: datasource=github-tags depName=kubernetes/kubernetes
 kubectl 1.27.2
-# renovate: datasource=github-tags depName=pre-commit/pre-commit
 pre-commit 3.3.3
 sops 3.7.3
 terraform 1.5.0
-# renovate: datasource=github-tags depName=terraform-docs/terraform-docs
 terraform-docs 0.16.0
-# renovate: datasource=github-tags depName=terraform-linters/tflint
 tflint 0.46.1
-# renovate: datasource=github-tags depName=aquasecurity/tfsec
 tfsec 1.28.1
 # renovate: datasource=github-tags depName=defenseunicorns/zarf
 zarf 0.27.1


### PR DESCRIPTION
Renovate now supports these tools natively, so we don't need to do a custom RegexManager for them. See https://docs.renovatebot.com/modules/manager/asdf/