### PR TITLE
Update Renovate scheduling

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -15,6 +15,17 @@
     // Apply crowd-sourced workarounds for known problems with packages. See https://docs.renovatebot.com/presets-workarounds/#workaroundsall
     "workarounds:all",
   ],
+  // If we don't specify a timezone then Renovate will use UTC
+  timezone: "America/New_York",
+  // Giving a small window constrains when Renovate will create PRs. This setting only affects when PRs are created. Without other configuration Renovate will rebase any PRs that already exist whenever it wants to.
+  // We need an "after" and a "before" because there is other automation that happens earlier that we don't want Renovate to conflict with.
+  schedule: [
+    // Other Renovate configs use "after 7am and before 9am every weekday". By using "after 9am and before 5pm every weekday" we have the opportunity to merge updates and release a new version BEFORE the other repos that consume this one are updated.
+    "after 9am and before 5pm every weekday"
+  ],
+  // This will prevent Renovate from automatically rebasing PRs. Without this, Renovate will rebase PRs whenever it wants to. The 'schedule' param is only for creating PRs. Because we are grouping all changes into one PR without this Renovate will be constantly rebasing that PR which we don't want since every time that happens another set of GHA status checks are kicked off.
+  // Using a value of "conflicted" means that Renovate will only rebase PRs if they are in a conflicted state. See https://docs.renovatebot.com/configuration-options/#rebasewhen
+  rebaseWhen: "conflicted",
   // Labels to set in Pull Request. See https://docs.renovatebot.com/configuration-options/#labels
   labels: [
     "renovate"


### PR DESCRIPTION
Other Renovate configs in repos that consume Build harness use "after 7am and before 9am every weekday". By using "after 9am and before 5pm every weekday" we have the opportunity to merge updates and release a new version BEFORE the other repos that consume this one are updated.