### PR TITLE
Add grype config file and ignore a false positive

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -1,0 +1,9 @@
+# Renovate handles app updates for us
+check-for-app-update: false
+
+# Automatically generate CPEs when packages have none
+add-cpes-if-none: true
+
+ignore:
+  # CVE-2018-9057 is a false positive. See https://github.com/anchore/grype/issues/1377.
+  - vulnerability: CVE-2018-9057

--- a/Makefile
+++ b/Makefile
@@ -56,5 +56,5 @@ vuln-report: ## Generate the vuln report from the sbom.syft.json file
 		-v "${PWD}:/app" \
 		--workdir "/app" \
 		${BUILD_HARNESS_REPO}:${BUILD_HARNESS_VERSION} \
-		bash -c 'cat ./sbom.syft.json | grype --add-cpes-if-none -o json --file vulns.grype.json \
-				&& cat ./sbom.syft.json | grype --add-cpes-if-none -o table --file vulns.grype.txt'
+		bash -c 'cat ./sbom.syft.json | grype -c ./.grype.yaml -o json --file vulns.grype.json \
+				&& cat ./sbom.syft.json | grype -c ./.grype.yaml -o table --file vulns.grype.txt'


### PR DESCRIPTION
Establish the Grype config file and ignore the 1 critical that Grype is reporting as a false positive.