### PR TITLE
Switch Renovate config for Zarf from github-tags to github-releases

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -19,5 +19,5 @@ terraform 1.5.2
 terraform-docs 0.16.0
 tflint 0.47.0
 tfsec 1.28.1
-# renovate: datasource=github-tags depName=defenseunicorns/zarf
+# renovate: datasource=github-releases depName=defenseunicorns/zarf
 zarf 0.28.1


### PR DESCRIPTION
Zarf's release process is such that tags may end up getting deleted if release tests fail. Looking at the release instead of the tag will reduce the risk that we pick up a change that will fail