### PR TITLE
Install Syft and Grype before trying to use them in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,8 @@ sbom: ## Generate an SBOM of the given image
 		-v "${PWD}:/app" \
 		--workdir "/app" \
 		${BUILD_HARNESS_REPO}:${BUILD_HARNESS_VERSION} \
-		bash -c 'syft "${IMAGE_TO_SCAN}" -o json=sbom.syft.json -o cyclonedx-json=sbom.cyclonedx.json -o spdx-json=sbom.spdx.json -o syft-table=sbom.table.txt'
+		bash -c 'asdf install syft \
+				&& syft "${IMAGE_TO_SCAN}" -o json=sbom.syft.json -o cyclonedx-json=sbom.cyclonedx.json -o spdx-json=sbom.spdx.json -o syft-table=sbom.table.txt'
 
 .PHONY: vuln-report
 vuln-report: ## Generate the vuln report from the sbom.syft.json file
@@ -56,5 +57,6 @@ vuln-report: ## Generate the vuln report from the sbom.syft.json file
 		-v "${PWD}:/app" \
 		--workdir "/app" \
 		${BUILD_HARNESS_REPO}:${BUILD_HARNESS_VERSION} \
-		bash -c 'cat ./sbom.syft.json | grype -c ./.grype.yaml -o json --file vulns.grype.json \
+		bash -c 'asdf install grype \
+				&& cat ./sbom.syft.json | grype -c ./.grype.yaml -o json --file vulns.grype.json \
 				&& cat ./sbom.syft.json | grype -c ./.grype.yaml -o table --file vulns.grype.txt'


### PR DESCRIPTION
If The version of Syft or Grype is being updated, the correct version won't be installed and this error will happen:

<img width="665" alt="image" src="https://github.com/defenseunicorns/build-harness/assets/16000938/9cbb897b-838b-4110-ae1a-a4680dc00506">

This change runs `asdf install syft` or `asdf install grype` before the tool needs to be used, to ensure that the needed version is installed before trying to use it.

Most of the time this will only add about 1 second to the pipeline runtime. It is only when syft or grype version is being updated that this needs to run an install.