### PR TITLE
ci(release): configure release-please to use a PAT

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,4 +15,5 @@ jobs:
     steps:
       - uses: google-github-actions/release-please-action@v3
         with:
+          token: ${{ secrets.PAT }}
           command: manifest


### PR DESCRIPTION
Configure release-please to use a PAT instead of the default token. This is needed since PRs that are created using the default token do not trigger automated status checks.