### PR TITLE
chore: change Renovate config rebaseWhen to "never"

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -24,8 +24,7 @@
     "after 9am and before 5pm every weekday"
   ],
   // This will prevent Renovate from automatically rebasing PRs. Without this, Renovate will rebase PRs whenever it wants to. The 'schedule' param is only for creating PRs. Because we are grouping all changes into one PR without this Renovate will be constantly rebasing that PR which we don't want since every time that happens another set of GHA status checks are kicked off.
-  // Using a value of "conflicted" means that Renovate will only rebase PRs if they are in a conflicted state. See https://docs.renovatebot.com/configuration-options/#rebasewhen
-  rebaseWhen: "conflicted",
+  rebaseWhen: "never",
   // Labels to set in Pull Request. See https://docs.renovatebot.com/configuration-options/#labels
   labels: [
     "renovate"


### PR DESCRIPTION
This will prevent Renovate from kicking off lots of unnecessary status checks.