### PR TITLE
chore(ci): Merge renovate PRs and change Build Harness dep Renovate trigger to Docker

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
 BUILD_HARNESS_REPO=ghcr.io/defenseunicorns/build-harness/build-harness
-# renovate: datasource=github-tags depName=defenseunicorns/build-harness
+# renovate: datasource=docker depName=ghcr.io/defenseunicorns/build-harness/build-harness
 BUILD_HARNESS_VERSION=2.0.1

--- a/renovate.json5
+++ b/renovate.json5
@@ -68,13 +68,13 @@
       matchPackageNames: ["terraform"],
       allowedVersions: "<1.6.0"
     },
+//    {
+//      matchPackageNames: ["anchore/syft"],
+//      groupName: "syft",
+//      automerge: true
+//    },
     {
-      matchPackageNames: ["anchore/syft"],
-      groupName: "syft",
-      automerge: true
-    },
-    {
-      excludePackageNames: ["anchore/syft"],
+      excludePackageNames: [],
       groupName: "stable",
       automerge: true
     }


### PR DESCRIPTION
- The issue causing build errors was resolved
- If the datasource is github-tags Renovate is likely to create a new PR before the new docker image is present in the registry.