### PR TITLE
docs: Update link to example repo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ test:
 
 Doing so would allow running the same command (`make test`) in your local environment, dev environment, or CI workflow. This results in more  repeatable environments. Stay tuned for a separate blog post that talks about this concept.
 
-To get a better idea of what it looks like to use Build Harness operationally, take a look at [this repo](https://github.com/defenseunicorns/terraform-aws-uds-vpc) where it is used. This pattern uses a Makefile to wrap actions that utilize Build Harness to run `make test` or `make pre-commit-all`.
+To get a better idea of what it looks like to use Build Harness operationally, take a look at [this repo](https://github.com/defenseunicorns/terraform-aws-vpc) where it is used. This pattern uses a Makefile to wrap actions that utilize Build Harness to run `make test` or `make pre-commit-all`.
 
 ### Contributing to Build Harness
 
@@ -140,4 +140,4 @@ A: Yes! Please submit a GitHub Issue [here](https://github.com/defenseunicorns/b
 
 **Q: I see that Docker is installed. Isn't that dangerous?**
 
-A: Mounting the Docker Socket is a security risk that requires other mitigations to be in place. See https://stackoverflow.com/a/41822163. Doing so will give the container root access to the host machine. No additional security risk is posed if this container is run without mounting the docker socket. It is our belief that this is safe to do on GitHub Actions hosted runners, since it is GitHub's own infrastructure that would be at risk if they didn't mitigate what would otherwise be an incredibly easy to exploit security hole. This is NOT regarded as safe to do on self-hosted runners without having taken some other mitigation step first.
+A: Mounting the Docker Socket is a security risk that requires other mitigations to be in place. See <https://stackoverflow.com/a/41822163>. Doing so will give the container root access to the host machine. No additional security risk is posed if this container is run without mounting the docker socket. It is our belief that this is safe to do on GitHub Actions hosted runners, since it is GitHub's own infrastructure that would be at risk if they didn't mitigate what would otherwise be an incredibly easy to exploit security hole. This is NOT regarded as safe to do on self-hosted runners without having taken some other mitigation step first.


### PR DESCRIPTION
Updates the README example link to https://github.com/defenseunicorns/terraform-aws-vpc. Previously that repo was named `terraform-aws-uds-vpc`. Until recently GitHub continued to forward links that still pointed to the previous name, however, a new repo was created recently using the old name and now existing links which were intended to go to the old repo are being sent to the new (still in very early development) repo. 