### PR TITLE
chore: update P1 certs, add httpd-tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,11 +17,13 @@ RUN ARCH_STRING=$(uname -m) \
     bzip2 \
     bzip2-devel \
     'dnf-command(config-manager)' \
+    ca-certificates \
     findutils \
     gcc \
     gcc-c++ \
     gettext \
     git \
+    httpd-tools \
     iptables-nft \
     jq \
     libffi-devel \


### PR DESCRIPTION
This PR includes the following updates and additions:
- updates the ca-certificates package to include the updated IronBank certificates. 
- adds httpd-tools for access to htpasswd.